### PR TITLE
Add CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+This repository is not meant for public contributions. It is used to publish
+official release tags for embedded builds.
+
+If you like to contribute to the Ettus Research UHD, FPGA, or meta-xxx
+repositories, you can find them (and their contribution guidelines) on github:
+
+- https://github.com/EttusResearch/uhd
+- https://github.com/EttusResearch/fpga
+- https://github.com/EttusResearch/meta-ettus
+


### PR DESCRIPTION
NI GitHub policy is to have a contributing file per repo (and license, and readme, we already have those).